### PR TITLE
Implement multi-circuit support with LocalEvaluator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,18 @@
 .PHONY: help
 help:
 	@echo "Available commands:"
-	@echo "  make xor      - Run XOR circuit test"
-	@echo "  make not      - Run NOT circuit test"
-	@echo "  make and      - Run AND circuit test with OT"
-	@echo "  make or       - Run OR circuit test"
-	@echo "  make all      - Run all tests"
-	@echo "  make build    - Build the project"
-	@echo "  make clean    - Clean build artifacts"
+	@echo "  make xor        - Run XOR circuit test"
+	@echo "  make not        - Run NOT circuit test"
+	@echo "  make and        - Run AND circuit test with OT"
+	@echo "  make or         - Run OR circuit test"
+	@echo "  make half-adder - Run half adder circuit test"
+	@echo "  make full-adder - Run full adder circuit test"
+	@echo "  make equality   - Run 2-bit equality circuit test"
+	@echo "  make mux        - Run 2-to-1 multiplexer circuit test"
+	@echo "  make all        - Run all basic gate tests"
+	@echo "  make multi      - Run all multi-gate circuit tests"
+	@echo "  make build      - Build the project"
+	@echo "  make clean      - Clean build artifacts"
 
 # Build the project
 .PHONY: build
@@ -54,6 +59,64 @@ or: build
 	@cargo run --quiet -- circuits/or.json 1 0
 	@cargo run --quiet -- circuits/or.json 1 1
 
-# Run all tests
+# Run half adder circuit
+.PHONY: half-adder
+half-adder: build
+	@echo "======== Half Adder Circuit ========"
+	@cargo run --quiet -- circuits/half_adder.json 0 0
+	@cargo run --quiet -- circuits/half_adder.json 0 1
+	@cargo run --quiet -- circuits/half_adder.json 1 0
+	@cargo run --quiet -- circuits/half_adder.json 1 1
+
+# Run full adder circuit
+.PHONY: full-adder
+full-adder: build
+	@echo "======== Full Adder Circuit ========"
+	@cargo run --quiet -- circuits/full_adder.json 0 0 0
+	@cargo run --quiet -- circuits/full_adder.json 0 0 1
+	@cargo run --quiet -- circuits/full_adder.json 0 1 0
+	@cargo run --quiet -- circuits/full_adder.json 0 1 1
+	@cargo run --quiet -- circuits/full_adder.json 1 0 0
+	@cargo run --quiet -- circuits/full_adder.json 1 0 1
+	@cargo run --quiet -- circuits/full_adder.json 1 1 0
+	@cargo run --quiet -- circuits/full_adder.json 1 1 1
+
+# Run 2-bit equality circuit
+.PHONY: equality
+equality: build
+	@echo "======== 2-bit Equality Circuit ========"
+	@echo "Testing: 00 == 00"
+	@cargo run --quiet -- circuits/two_bit_equality.json 0 0 0 0
+	@echo "Testing: 01 == 01"
+	@cargo run --quiet -- circuits/two_bit_equality.json 0 1 0 1
+	@echo "Testing: 10 == 10"
+	@cargo run --quiet -- circuits/two_bit_equality.json 1 0 1 0
+	@echo "Testing: 11 == 11"
+	@cargo run --quiet -- circuits/two_bit_equality.json 1 1 1 1
+	@echo "Testing: 00 != 11"
+	@cargo run --quiet -- circuits/two_bit_equality.json 0 0 1 1
+	@echo "Testing: 10 != 01"
+	@cargo run --quiet -- circuits/two_bit_equality.json 1 0 0 1
+
+# Run 2-to-1 multiplexer circuit
+.PHONY: mux
+mux: build
+	@echo "======== 2-to-1 Multiplexer Circuit ========"
+	@echo "sel=0: select a"
+	@cargo run --quiet -- circuits/mux_2to1.json 0 0 0
+	@cargo run --quiet -- circuits/mux_2to1.json 1 0 0
+	@cargo run --quiet -- circuits/mux_2to1.json 0 1 0
+	@cargo run --quiet -- circuits/mux_2to1.json 1 1 0
+	@echo "sel=1: select b"
+	@cargo run --quiet -- circuits/mux_2to1.json 0 0 1
+	@cargo run --quiet -- circuits/mux_2to1.json 1 0 1
+	@cargo run --quiet -- circuits/mux_2to1.json 0 1 1
+	@cargo run --quiet -- circuits/mux_2to1.json 1 1 1
+
+# Run all basic gate tests
 .PHONY: all
 all: xor not and or
+
+# Run all multi-gate circuit tests
+.PHONY: multi
+multi: half-adder full-adder equality mux

--- a/circuits/and.json
+++ b/circuits/and.json
@@ -1,6 +1,15 @@
 {
   "name": "AND_gate",
-  "description": "Simple AND gate using OT protocol",
+  "description": "Basic AND gate with two inputs",
+  "metadata": {
+    "input_count": 2,
+    "outputs": [
+      {
+        "name": "result",
+        "gate_id": 3
+      }
+    ]
+  },
   "gates": [
     {
       "id": 3,

--- a/circuits/complex_circuit.json
+++ b/circuits/complex_circuit.json
@@ -1,0 +1,41 @@
+{
+  "name": "complex_circuit",
+  "description": "A more complex circuit verified using local evaluation",
+  "metadata": {
+    "input_count": 3,
+    "outputs": [
+      {
+        "name": "intermediate",
+        "gate_id": 100,
+        "verify_with_circuit": true
+      },
+      {
+        "name": "final",
+        "gate_id": 103,
+        "verify_with_circuit": true
+      }
+    ]
+  },
+  "gates": [
+    {
+      "id": 100,
+      "type": "AND",
+      "in": [1, 2]
+    },
+    {
+      "id": 101,
+      "type": "XOR",
+      "in": [2, 3]
+    },
+    {
+      "id": 102,
+      "type": "OR",
+      "in": [100, 101]
+    },
+    {
+      "id": 103,
+      "type": "NOT",
+      "in": [102]
+    }
+  ]
+}

--- a/circuits/full_adder.json
+++ b/circuits/full_adder.json
@@ -1,0 +1,44 @@
+{
+  "name": "full_adder",
+  "description": "Full-adder: adds three bits with carry",
+  "metadata": {
+    "input_count": 3,
+    "outputs": [
+      {
+        "name": "sum",
+        "gate_id": 102
+      },
+      {
+        "name": "carry",
+        "gate_id": 104
+      }
+    ]
+  },
+  "gates": [
+    {
+      "id": 100,
+      "type": "XOR",
+      "in": [1, 2]
+    },
+    {
+      "id": 101,
+      "type": "AND",
+      "in": [1, 2]
+    },
+    {
+      "id": 102,
+      "type": "XOR",
+      "in": [100, 3]
+    },
+    {
+      "id": 103,
+      "type": "AND",
+      "in": [100, 3]
+    },
+    {
+      "id": 104,
+      "type": "OR",
+      "in": [101, 103]
+    }
+  ]
+}

--- a/circuits/half_adder.json
+++ b/circuits/half_adder.json
@@ -1,0 +1,29 @@
+{
+  "name": "half_adder",
+  "description": "Half-adder: computes sum and carry for two bits",
+  "metadata": {
+    "input_count": 2,
+    "outputs": [
+      {
+        "name": "sum",
+        "gate_id": 100
+      },
+      {
+        "name": "carry",
+        "gate_id": 101
+      }
+    ]
+  },
+  "gates": [
+    {
+      "id": 100,
+      "type": "XOR",
+      "in": [1, 2]
+    },
+    {
+      "id": 101,
+      "type": "AND",
+      "in": [1, 2]
+    }
+  ]
+}

--- a/circuits/half_adder_no_formula.json
+++ b/circuits/half_adder_no_formula.json
@@ -1,0 +1,29 @@
+{
+  "name": "half_adder_no_formula",
+  "description": "Half-adder without expected formulas - uses circuit evaluation",
+  "metadata": {
+    "input_count": 2,
+    "outputs": [
+      {
+        "name": "sum",
+        "gate_id": 100
+      },
+      {
+        "name": "carry",
+        "gate_id": 101
+      }
+    ]
+  },
+  "gates": [
+    {
+      "id": 100,
+      "type": "XOR",
+      "in": [1, 2]
+    },
+    {
+      "id": 101,
+      "type": "AND",
+      "in": [1, 2]
+    }
+  ]
+}

--- a/circuits/mux_2to1.json
+++ b/circuits/mux_2to1.json
@@ -1,0 +1,35 @@
+{
+  "name": "mux_2to1",
+  "description": "2-to-1 multiplexer: selects between two inputs",
+  "metadata": {
+    "input_count": 3,
+    "outputs": [
+      {
+        "name": "result",
+        "gate_id": 103
+      }
+    ]
+  },
+  "gates": [
+    {
+      "id": 100,
+      "type": "NOT",
+      "in": [3]
+    },
+    {
+      "id": 101,
+      "type": "AND",
+      "in": [100, 1]
+    },
+    {
+      "id": 102,
+      "type": "AND",
+      "in": [3, 2]
+    },
+    {
+      "id": 103,
+      "type": "OR",
+      "in": [101, 102]
+    }
+  ]
+}

--- a/circuits/not.json
+++ b/circuits/not.json
@@ -1,6 +1,15 @@
 {
   "name": "NOT_gate",
   "description": "Simple NOT gate",
+  "metadata": {
+    "input_count": 1,
+    "outputs": [
+      {
+        "name": "result",
+        "gate_id": 2
+      }
+    ]
+  },
   "gates": [
     {
       "id": 2,

--- a/circuits/or.json
+++ b/circuits/or.json
@@ -1,6 +1,15 @@
 {
   "name": "OR_gate",
   "description": "Simple OR gate using De Morgan's law",
+  "metadata": {
+    "input_count": 2,
+    "outputs": [
+      {
+        "name": "result",
+        "gate_id": 3
+      }
+    ]
+  },
   "gates": [
     {
       "id": 3,

--- a/circuits/two_bit_equality.json
+++ b/circuits/two_bit_equality.json
@@ -1,0 +1,40 @@
+{
+  "name": "two_bit_equality",
+  "description": "Checks if two 2-bit numbers are equal",
+  "metadata": {
+    "input_count": 4,
+    "outputs": [
+      {
+        "name": "equal",
+        "gate_id": 104
+      }
+    ]
+  },
+  "gates": [
+    {
+      "id": 100,
+      "type": "XOR",
+      "in": [1, 3]
+    },
+    {
+      "id": 101,
+      "type": "XOR",
+      "in": [2, 4]
+    },
+    {
+      "id": 102,
+      "type": "NOT",
+      "in": [100]
+    },
+    {
+      "id": 103,
+      "type": "NOT",
+      "in": [101]
+    },
+    {
+      "id": 104,
+      "type": "AND",
+      "in": [102, 103]
+    }
+  ]
+}

--- a/circuits/xor.json
+++ b/circuits/xor.json
@@ -1,6 +1,15 @@
 {
   "name": "XOR_gate",
   "description": "Simple XOR gate",
+  "metadata": {
+    "input_count": 2,
+    "outputs": [
+      {
+        "name": "result",
+        "gate_id": 3
+      }
+    ]
+  },
   "gates": [
     {
       "id": 3,

--- a/src/circuit/evaluator.rs
+++ b/src/circuit/evaluator.rs
@@ -1,0 +1,108 @@
+use crate::circuit::{Circuit, GateType};
+use anyhow::Result;
+use std::collections::HashMap;
+
+/// Evaluate a circuit locally (without secret sharing) for verification purposes
+pub struct LocalEvaluator;
+
+impl LocalEvaluator {
+    /// Evaluate a circuit with given inputs and return all gate outputs
+    pub fn evaluate(circuit: &Circuit, inputs: &[bool]) -> Result<HashMap<u32, bool>> {
+        let mut wire_values = HashMap::new();
+
+        // Initialize input wires
+        for (i, &input) in inputs.iter().enumerate() {
+            wire_values.insert((i + 1) as u32, input);
+        }
+
+        // Evaluate each gate in order
+        for gate in &circuit.gates {
+            let result = match gate.gate_type {
+                GateType::AND => {
+                    let a = Self::get_wire_value(&wire_values, gate.inputs[0])?;
+                    let b = Self::get_wire_value(&wire_values, gate.inputs[1])?;
+                    a & b
+                }
+                GateType::OR => {
+                    let a = Self::get_wire_value(&wire_values, gate.inputs[0])?;
+                    let b = Self::get_wire_value(&wire_values, gate.inputs[1])?;
+                    a | b
+                }
+                GateType::XOR => {
+                    let a = Self::get_wire_value(&wire_values, gate.inputs[0])?;
+                    let b = Self::get_wire_value(&wire_values, gate.inputs[1])?;
+                    a ^ b
+                }
+                GateType::NOT => {
+                    let a = Self::get_wire_value(&wire_values, gate.inputs[0])?;
+                    !a
+                }
+            };
+
+            wire_values.insert(gate.id, result);
+        }
+
+        Ok(wire_values)
+    }
+
+    /// Get the output value for a specific gate
+    pub fn get_output(circuit: &Circuit, inputs: &[bool], gate_id: u32) -> Result<bool> {
+        let wire_values = Self::evaluate(circuit, inputs)?;
+        wire_values
+            .get(&gate_id)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("Gate {} not found in circuit", gate_id))
+    }
+
+    /// Helper to get wire value with error handling
+    fn get_wire_value(wire_values: &HashMap<u32, bool>, wire_id: u32) -> Result<bool> {
+        wire_values
+            .get(&wire_id)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("Wire {} not found", wire_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuit::{Circuit, CircuitMetadata, Gate, GateType, OutputInfo};
+
+    #[test]
+    fn test_local_evaluator_and_gate() {
+        let circuit = Circuit {
+            name: "test_and".to_string(),
+            description: "Test AND gate".to_string(),
+            gates: vec![Gate {
+                id: 3,
+                gate_type: GateType::AND,
+                inputs: vec![1, 2],
+            }],
+            metadata: CircuitMetadata {
+                input_count: 2,
+                outputs: vec![OutputInfo {
+                    name: "result".to_string(),
+                    gate_id: 3,
+                }],
+            },
+        };
+
+        // Test all combinations
+        assert_eq!(
+            LocalEvaluator::get_output(&circuit, &[false, false], 3).unwrap(),
+            false
+        );
+        assert_eq!(
+            LocalEvaluator::get_output(&circuit, &[false, true], 3).unwrap(),
+            false
+        );
+        assert_eq!(
+            LocalEvaluator::get_output(&circuit, &[true, false], 3).unwrap(),
+            false
+        );
+        assert_eq!(
+            LocalEvaluator::get_output(&circuit, &[true, true], 3).unwrap(),
+            true
+        );
+    }
+}

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -1,3 +1,5 @@
+pub mod evaluator;
 pub mod types;
 
+pub use evaluator::LocalEvaluator;
 pub use types::*;

--- a/src/circuit/types.rs
+++ b/src/circuit/types.rs
@@ -8,6 +8,8 @@ pub struct Circuit {
     #[serde(default)]
     pub description: String,
     pub gates: Vec<Gate>,
+    #[serde(default)]
+    pub metadata: CircuitMetadata,
 }
 
 impl Circuit {
@@ -38,4 +40,16 @@ pub enum GateType {
     NOT,
     AND,
     OR,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CircuitMetadata {
+    pub input_count: usize,
+    pub outputs: Vec<OutputInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputInfo {
+    pub name: String,
+    pub gate_id: u32,
 }


### PR DESCRIPTION
## Summary
- Implement support for multi-gate circuits where output shares become input shares for subsequent gates
- Add LocalEvaluator for circuit-based verification instead of formula-based evaluation
- Centralize circuit evaluation logic in party.rs with execute_circuit function
- Remove CircuitBuilder utility and simplify circuit construction
- Add metadata support to basic gates (AND, OR, XOR, NOT) circuits

## Changes
- Added multi-gate circuit examples: half-adder, full-adder, mux, two-bit equality
- Moved circuit evaluation from main.rs to party.rs for better organization
- Updated all circuit JSON files with proper metadata including input_count and outputs
- Removed formula-based evaluation in favor of consistent circuit-based evaluation
- Added Makefile commands for running different circuit types

## Test plan
- [x] All existing tests pass
- [x] Basic gates (AND, OR, XOR, NOT) work with new metadata format
- [x] Multi-gate circuits (half-adder, full-adder) evaluate correctly
- [x] LocalEvaluator properly verifies circuit outputs
- [x] Execute_circuit function handles complex circuit evaluation

🤖 Generated with [Claude Code](https://claude.ai/code)