### PR TITLE
Implement 3-party GMW protocol with unified interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "oblivious-transfer-rs"
 version = "0.1.0"
-source = "git+https://github.com/kobakaku/oblivious-transfer-rs?rev=570ea6abf204b1b01ab2d6851d83807878f23f24#570ea6abf204b1b01ab2d6851d83807878f23f24"
+source = "git+https://github.com/kobakaku/oblivious-transfer-rs?rev=6f0dddb3b9a55b46cb27db7858a1f0c5d0af9541#6f0dddb3b9a55b46cb27db7858a1f0c5d0af9541"
 dependencies = [
  "anyhow",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.8"
 anyhow = "1.0"
-oblivious-transfer-rs = { git = "https://github.com/kobakaku/oblivious-transfer-rs", rev = "570ea6abf204b1b01ab2d6851d83807878f23f24" }
+oblivious-transfer-rs = { git = "https://github.com/kobakaku/oblivious-transfer-rs", rev = "6f0dddb3b9a55b46cb27db7858a1f0c5d0af9541" }
+

--- a/src/gates/and_3party.rs
+++ b/src/gates/and_3party.rs
@@ -1,0 +1,154 @@
+use crate::ot::BitOT;
+use anyhow::Result;
+use rand::random;
+
+/// 3-party AND gate implementation for local simulation (Phase 1)
+///
+/// In 3-party GMW: z = x AND y where:
+/// - x = x0 ⊕ x1 ⊕ x2
+/// - y = y0 ⊕ y1 ⊕ y2
+///
+/// The AND computation expands to:
+/// z = (x0·y0 ⊕ x1·y1 ⊕ x2·y2) ⊕ ((x0·y1 ⊕ x1·y0) ⊕ (x0·y2 ⊕ x2·y0) ⊕ (x1·y2 ⊕ x2·y1))
+///
+/// Each party Pi computes:
+/// - Local term: xi·yi (computed locally)
+/// - Cross terms: xi·yj ⊕ xj·yi with other parties (using OT)
+pub fn and_gate_3party_local(
+    party_shares: [(bool, bool); 3], // Each party's (x_share, y_share)
+) -> Result<[bool; 3]> {
+    let [(x0, y0), (x1, y1), (x2, y2)] = party_shares;
+
+    // Each party computes their local term xi·yi
+    let local_terms = [x0 & y0, x1 & y1, x2 & y2];
+
+    // Simulate OT between each pair of parties
+    // We need 3 OT sessions: (0,1), (0,2), (1,2)
+
+    // OT between Party 0 and Party 1
+    let (cross_01_for_p0, cross_01_for_p1) = compute_cross_term_ot((x0, y0), (x1, y1), 0, 1)?;
+
+    // OT between Party 0 and Party 2
+    let (cross_02_for_p0, cross_02_for_p2) = compute_cross_term_ot((x0, y0), (x2, y2), 0, 2)?;
+
+    // OT between Party 1 and Party 2
+    let (cross_12_for_p1, cross_12_for_p2) = compute_cross_term_ot((x1, y1), (x2, y2), 1, 2)?;
+
+    // Each party combines their local term with cross terms
+    let result_shares = [
+        local_terms[0] ^ cross_01_for_p0 ^ cross_02_for_p0, // Party 0
+        local_terms[1] ^ cross_01_for_p1 ^ cross_12_for_p1, // Party 1
+        local_terms[2] ^ cross_02_for_p2 ^ cross_12_for_p2, // Party 2
+    ];
+
+    Ok(result_shares)
+}
+
+/// Compute cross term xi·yj ⊕ xj·yi between two parties using OT
+/// Returns shares for both parties such that:
+/// share_i ⊕ share_j = xi·yj ⊕ xj·yi
+fn compute_cross_term_ot(
+    party_i: (bool, bool), // (xi, yi)
+    party_j: (bool, bool), // (xj, yj)
+    i: usize,
+    j: usize,
+) -> Result<(bool, bool)> {
+    let (xi, yi) = party_i;
+    let (xj, yj) = party_j;
+
+    // Party i acts as sender, party j as receiver
+    // We need to compute xi·yj ⊕ xj·yi securely
+
+    // Party i generates random bit ri (will be party i's share)
+    let ri = random::<bool>();
+
+    // Party j needs to receive: (xi·yj ⊕ xj·yi) ⊕ ri
+    // Using 1-out-of-4 OT based on (xj, yj) as choice bits
+
+    // Party i prepares 4 messages for all possible (xj, yj) values:
+    // (0,0): xi·0 ⊕ 0·yi ⊕ ri = 0 ⊕ ri = ri
+    // (0,1): xi·1 ⊕ 0·yi ⊕ ri = xi ⊕ ri
+    // (1,0): xi·0 ⊕ 1·yi ⊕ ri = yi ⊕ ri
+    // (1,1): xi·1 ⊕ 1·yi ⊕ ri = xi ⊕ yi ⊕ ri
+
+    let messages = (
+        ri,           // (0,0)
+        xi ^ ri,      // (0,1)
+        yi ^ ri,      // (1,0)
+        xi ^ yi ^ ri, // (1,1)
+    );
+
+    // Execute 1-out-of-4 OT (simulated locally for Phase 1)
+    let rj = BitOT::execute_1_out_of_4(messages, (xj, yj))?;
+
+    // Return shares based on party order
+    if i < j {
+        Ok((ri, rj)) // Party i gets ri, party j gets rj
+    } else {
+        Ok((rj, ri)) // Swap if parties are in opposite order
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::party::{reconstruct_shares_3party, secret_share_3party};
+
+    #[test]
+    fn test_3party_and_gate_local() -> Result<()> {
+        // Test all input combinations
+        for x in [false, true] {
+            for y in [false, true] {
+                // Create 3-party shares
+                let (x0, x1, x2) = secret_share_3party(x);
+                let (y0, y1, y2) = secret_share_3party(y);
+
+                // Execute 3-party AND gate
+                let party_shares = [(x0, y0), (x1, y1), (x2, y2)];
+                let result_shares = and_gate_3party_local(party_shares)?;
+
+                // Reconstruct result
+                let result =
+                    reconstruct_shares_3party(result_shares[0], result_shares[1], result_shares[2]);
+
+                assert_eq!(
+                    result,
+                    x & y,
+                    "3-party AND({}, {}) failed: expected {}, got {}",
+                    x,
+                    y,
+                    x & y,
+                    result
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cross_term_correctness() -> Result<()> {
+        // Test that cross terms compute correctly
+        for xi in [false, true] {
+            for yi in [false, true] {
+                for xj in [false, true] {
+                    for yj in [false, true] {
+                        let (share_i, share_j) = compute_cross_term_ot((xi, yi), (xj, yj), 0, 1)?;
+
+                        // Verify that shares reconstruct to the correct cross term
+                        let reconstructed = share_i ^ share_j;
+                        let expected = (xi & yj) ^ (xj & yi);
+
+                        assert_eq!(
+                            reconstructed, expected,
+                            "Cross term failed for ({},{}) and ({},{})",
+                            xi, yi, xj, yj
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -1,9 +1,17 @@
 pub mod and;
+pub mod and_3party;
 pub mod not;
+pub mod not_3party;
 pub mod or;
+pub mod or_3party;
 pub mod xor;
+pub mod xor_3party;
 
 pub use and::and_gate;
+pub use and_3party::and_gate_3party_local;
 pub use not::not_gate;
+pub use not_3party::not_gate_3party;
 pub use or::or_gate;
+pub use or_3party::or_gate_3party_local;
 pub use xor::xor_gate;
+pub use xor_3party::xor_gate_3party;

--- a/src/gates/not_3party.rs
+++ b/src/gates/not_3party.rs
@@ -1,0 +1,9 @@
+/// 3-party NOT gate
+/// Party 0 flips their share, others keep theirs unchanged
+pub fn not_gate_3party(party_id: u32, share: bool) -> bool {
+    if party_id == 0 {
+        !share
+    } else {
+        share
+    }
+}

--- a/src/gates/or_3party.rs
+++ b/src/gates/or_3party.rs
@@ -1,0 +1,41 @@
+use crate::gates::{and_gate_3party_local, not_gate_3party};
+use anyhow::Result;
+
+/// 3-party OR gate using De Morgan's law
+/// x OR y = NOT(NOT(x) AND NOT(y))
+pub fn or_gate_3party_local(
+    _party_id: u32,
+    party_shares: [(bool, bool); 3], // Each party's (x_share, y_share)
+) -> Result<[bool; 3]> {
+    // Apply NOT to each party's shares
+    let not_x_shares: [bool; 3] = [
+        not_gate_3party(0, party_shares[0].0),
+        not_gate_3party(1, party_shares[1].0),
+        not_gate_3party(2, party_shares[2].0),
+    ];
+
+    let not_y_shares: [bool; 3] = [
+        not_gate_3party(0, party_shares[0].1),
+        not_gate_3party(1, party_shares[1].1),
+        not_gate_3party(2, party_shares[2].1),
+    ];
+
+    // Prepare shares for AND gate
+    let and_input_shares = [
+        (not_x_shares[0], not_y_shares[0]),
+        (not_x_shares[1], not_y_shares[1]),
+        (not_x_shares[2], not_y_shares[2]),
+    ];
+
+    // Compute NOT(x) AND NOT(y)
+    let and_result = and_gate_3party_local(and_input_shares)?;
+
+    // Apply final NOT
+    let or_result = [
+        not_gate_3party(0, and_result[0]),
+        not_gate_3party(1, and_result[1]),
+        not_gate_3party(2, and_result[2]),
+    ];
+
+    Ok(or_result)
+}

--- a/src/gates/xor_3party.rs
+++ b/src/gates/xor_3party.rs
@@ -1,0 +1,5 @@
+/// 3-party XOR gate - each party computes locally
+/// Since XOR is linear in GF(2), no communication is needed
+pub fn xor_gate_3party(x_share: bool, y_share: bool) -> bool {
+    x_share ^ y_share
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,13 @@ use anyhow::Result;
 use std::collections::HashMap;
 use std::env;
 
-use gmw_rs::{execute_circuit, reconstruct_shares, secret_share, Circuit, LocalEvaluator};
+use gmw_rs::{
+    execute_circuit, reconstruct_shares, reconstruct_shares_3party, secret_share,
+    secret_share_3party, Circuit, LocalEvaluator, PartyShares,
+};
 
-/// Run a circuit with any number of inputs
-fn run_circuit(circuit_file: &str, inputs: Vec<bool>) -> Result<()> {
+/// Run a circuit with unified interface
+fn run_circuit(circuit_file: &str, inputs: Vec<bool>, use_3party: bool) -> Result<()> {
     let circuit = Circuit::from_file(circuit_file)?;
 
     // Validate input count
@@ -17,20 +20,45 @@ fn run_circuit(circuit_file: &str, inputs: Vec<bool>) -> Result<()> {
         ));
     }
 
-    // Create secret shares for all inputs
-    let mut alice_shares = HashMap::new();
-    let mut bob_shares = HashMap::new();
+    // Create shares and evaluate circuit based on party count
+    let result_shares = if use_3party {
+        // Create 3-party secret shares
+        let mut party0_shares = HashMap::new();
+        let mut party1_shares = HashMap::new();
+        let mut party2_shares = HashMap::new();
 
-    for (i, &input) in inputs.iter().enumerate() {
-        let (alice_share, bob_share) = secret_share(input);
-        let wire_id = (i + 1) as u32; // Wire IDs start from 1
-        alice_shares.insert(wire_id, alice_share);
-        bob_shares.insert(wire_id, bob_share);
-    }
+        for (i, &input) in inputs.iter().enumerate() {
+            let (share0, share1, share2) = secret_share_3party(input);
+            let wire_id = (i + 1) as u32;
+            party0_shares.insert(wire_id, share0);
+            party1_shares.insert(wire_id, share1);
+            party2_shares.insert(wire_id, share2);
+        }
 
-    // Evaluate circuit
-    let (alice_result_shares, bob_result_shares) =
-        execute_circuit(&circuit, &alice_shares, &bob_shares)?;
+        let shares = PartyShares::ThreeParty {
+            party0: party0_shares,
+            party1: party1_shares,
+            party2: party2_shares,
+        };
+        execute_circuit(&circuit, shares)?
+    } else {
+        // Create 2-party secret shares
+        let mut alice_shares = HashMap::new();
+        let mut bob_shares = HashMap::new();
+
+        for (i, &input) in inputs.iter().enumerate() {
+            let (alice_share, bob_share) = secret_share(input);
+            let wire_id = (i + 1) as u32;
+            alice_shares.insert(wire_id, alice_share);
+            bob_shares.insert(wire_id, bob_share);
+        }
+
+        let shares = PartyShares::TwoParty {
+            alice: alice_shares,
+            bob: bob_shares,
+        };
+        execute_circuit(&circuit, shares)?
+    };
 
     println!("Inputs: {inputs:?}");
 
@@ -43,16 +71,34 @@ fn run_circuit(circuit_file: &str, inputs: Vec<bool>) -> Result<()> {
 
     println!("Outputs:");
     for output_info in &circuit.metadata.outputs {
-        let alice_output = alice_result_shares
-            .get(&output_info.gate_id)
-            .copied()
-            .ok_or_else(|| anyhow::anyhow!("Missing output gate {}", output_info.gate_id))?;
-        let bob_output = bob_result_shares
-            .get(&output_info.gate_id)
-            .copied()
-            .ok_or_else(|| anyhow::anyhow!("Missing output gate {}", output_info.gate_id))?;
+        let result = match &result_shares {
+            PartyShares::TwoParty { alice, bob } => {
+                let alice_output = alice.get(&output_info.gate_id).copied().ok_or_else(|| {
+                    anyhow::anyhow!("Missing output gate {}", output_info.gate_id)
+                })?;
+                let bob_output = bob.get(&output_info.gate_id).copied().ok_or_else(|| {
+                    anyhow::anyhow!("Missing output gate {}", output_info.gate_id)
+                })?;
+                reconstruct_shares(alice_output, bob_output)
+            }
+            PartyShares::ThreeParty {
+                party0,
+                party1,
+                party2,
+            } => {
+                let party0_output = party0.get(&output_info.gate_id).copied().ok_or_else(|| {
+                    anyhow::anyhow!("Missing output gate {}", output_info.gate_id)
+                })?;
+                let party1_output = party1.get(&output_info.gate_id).copied().ok_or_else(|| {
+                    anyhow::anyhow!("Missing output gate {}", output_info.gate_id)
+                })?;
+                let party2_output = party2.get(&output_info.gate_id).copied().ok_or_else(|| {
+                    anyhow::anyhow!("Missing output gate {}", output_info.gate_id)
+                })?;
+                reconstruct_shares_3party(party0_output, party1_output, party2_output)
+            }
+        };
 
-        let result = reconstruct_shares(alice_output, bob_output);
         print!("  {} = {}", output_info.name, result);
 
         // Always verify using local circuit evaluation
@@ -66,15 +112,17 @@ fn run_circuit(circuit_file: &str, inputs: Vec<bool>) -> Result<()> {
 }
 
 fn print_usage() {
-    println!("Usage: cargo run -- <circuit.json> <input1> [input2] [input3] ...");
+    println!("Usage: cargo run -- [--3party] <circuit.json> <input1> [input2] [input3] ...");
+    println!();
+    println!("Options:");
+    println!("  --3party    Use 3-party computation (local simulation)");
     println!();
     println!("Examples:");
     println!("  cargo run -- circuits/not.json 1");
     println!("  cargo run -- circuits/and.json 1 0");
     println!("  cargo run -- circuits/half_adder.json 1 1");
-    println!("  cargo run -- circuits/full_adder.json 1 1 0");
-    println!("  cargo run -- circuits/two_bit_equality.json 1 0 1 0");
-    println!("  cargo run -- circuits/mux_2to1.json 1 0 1");
+    println!("  cargo run -- --3party circuits/and.json 1 0");
+    println!("  cargo run -- --3party circuits/xor.json 1 0");
 }
 
 fn main() -> Result<()> {
@@ -85,10 +133,22 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let circuit_file = &args[1];
+    // Check for --3party flag
+    let (use_3party, remaining_args) = if args.len() > 1 && args[1] == "--3party" {
+        (true, &args[2..])
+    } else {
+        (false, &args[1..])
+    };
+
+    if remaining_args.is_empty() {
+        print_usage();
+        return Ok(());
+    }
+
+    let circuit_file = &remaining_args[0];
 
     // Parse all remaining arguments as boolean inputs
-    let inputs: Result<Vec<bool>, _> = args[2..]
+    let inputs: Result<Vec<bool>, _> = remaining_args[1..]
         .iter()
         .map(|s| s.parse::<u8>().map(|v| v != 0))
         .collect();
@@ -99,5 +159,5 @@ fn main() -> Result<()> {
         println!("Warning: No inputs provided");
     }
 
-    run_circuit(circuit_file, inputs)
+    run_circuit(circuit_file, inputs, use_3party)
 }

--- a/src/party.rs
+++ b/src/party.rs
@@ -2,10 +2,55 @@ use anyhow::Result;
 use std::collections::HashMap;
 
 use crate::circuit::{Circuit, GateType};
-use crate::gates::{and_gate, not_gate, or_gate, xor_gate};
+use crate::gates::{
+    and_gate, and_gate_3party_local, not_gate, not_gate_3party, or_gate, xor_gate, xor_gate_3party,
+};
+
+/// Type alias for three-party computation results
+type ThreePartyShares = (HashMap<u32, bool>, HashMap<u32, bool>, HashMap<u32, bool>);
+
+/// Party shares for multi-party computation
+#[derive(Debug, Clone)]
+pub enum PartyShares {
+    TwoParty {
+        alice: HashMap<u32, bool>,
+        bob: HashMap<u32, bool>,
+    },
+    ThreeParty {
+        party0: HashMap<u32, bool>,
+        party1: HashMap<u32, bool>,
+        party2: HashMap<u32, bool>,
+    },
+}
+
+/// Evaluate a complete circuit with multi-party support
+pub fn execute_circuit(circuit: &Circuit, shares: PartyShares) -> Result<PartyShares> {
+    match shares {
+        PartyShares::TwoParty { alice, bob } => {
+            let (alice_result, bob_result) = execute_circuit_2party(circuit, &alice, &bob)?;
+            Ok(PartyShares::TwoParty {
+                alice: alice_result,
+                bob: bob_result,
+            })
+        }
+        PartyShares::ThreeParty {
+            party0,
+            party1,
+            party2,
+        } => {
+            let (p0_result, p1_result, p2_result) =
+                execute_circuit_3party(circuit, &party0, &party1, &party2)?;
+            Ok(PartyShares::ThreeParty {
+                party0: p0_result,
+                party1: p1_result,
+                party2: p2_result,
+            })
+        }
+    }
+}
 
 /// Evaluate a complete circuit with two parties and return all intermediate shares
-pub fn execute_circuit(
+pub fn execute_circuit_2party(
     circuit: &Circuit,
     alice_shares: &HashMap<u32, bool>,
     bob_shares: &HashMap<u32, bool>,
@@ -107,12 +152,195 @@ pub fn execute_circuit(
     Ok((alice_output_shares, bob_output_shares))
 }
 
-pub fn secret_share(value: bool) -> (bool, bool) {
-    let share1 = rand::random::<bool>();
-    let share2 = value ^ share1;
-    (share1, share2)
+/// Evaluate a complete circuit with three parties and return all intermediate shares
+pub fn execute_circuit_3party(
+    circuit: &Circuit,
+    party0_shares: &HashMap<u32, bool>,
+    party1_shares: &HashMap<u32, bool>,
+    party2_shares: &HashMap<u32, bool>,
+) -> Result<ThreePartyShares> {
+    let mut p0_output_shares = party0_shares.clone();
+    let mut p1_output_shares = party1_shares.clone();
+    let mut p2_output_shares = party2_shares.clone();
+
+    for gate in &circuit.gates {
+        match gate.gate_type {
+            GateType::XOR => {
+                let p0_a = p0_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 0 input A"))?;
+                let p0_b = p0_output_shares
+                    .get(&gate.inputs[1])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 0 input B"))?;
+                let p1_a = p1_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 1 input A"))?;
+                let p1_b = p1_output_shares
+                    .get(&gate.inputs[1])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 1 input B"))?;
+                let p2_a = p2_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 2 input A"))?;
+                let p2_b = p2_output_shares
+                    .get(&gate.inputs[1])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 2 input B"))?;
+
+                let p0_result = xor_gate_3party(p0_a, p0_b);
+                let p1_result = xor_gate_3party(p1_a, p1_b);
+                let p2_result = xor_gate_3party(p2_a, p2_b);
+
+                p0_output_shares.insert(gate.id, p0_result);
+                p1_output_shares.insert(gate.id, p1_result);
+                p2_output_shares.insert(gate.id, p2_result);
+            }
+            GateType::NOT => {
+                let p0_input = p0_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 0 input"))?;
+                let p1_input = p1_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 1 input"))?;
+                let p2_input = p2_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 2 input"))?;
+
+                let p0_result = not_gate_3party(0, p0_input);
+                let p1_result = not_gate_3party(1, p1_input);
+                let p2_result = not_gate_3party(2, p2_input);
+
+                p0_output_shares.insert(gate.id, p0_result);
+                p1_output_shares.insert(gate.id, p1_result);
+                p2_output_shares.insert(gate.id, p2_result);
+            }
+            GateType::AND => {
+                let p0_a = p0_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 0 input A"))?;
+                let p0_b = p0_output_shares
+                    .get(&gate.inputs[1])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 0 input B"))?;
+                let p1_a = p1_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 1 input A"))?;
+                let p1_b = p1_output_shares
+                    .get(&gate.inputs[1])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 1 input B"))?;
+                let p2_a = p2_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 2 input A"))?;
+                let p2_b = p2_output_shares
+                    .get(&gate.inputs[1])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 2 input B"))?;
+
+                let party_shares = [(p0_a, p0_b), (p1_a, p1_b), (p2_a, p2_b)];
+                let result_shares = and_gate_3party_local(party_shares)?;
+
+                p0_output_shares.insert(gate.id, result_shares[0]);
+                p1_output_shares.insert(gate.id, result_shares[1]);
+                p2_output_shares.insert(gate.id, result_shares[2]);
+            }
+            GateType::OR => {
+                // OR gate using De Morgan's law: A OR B = NOT(NOT(A) AND NOT(B))
+                // For now, we'll implement this as a combination of NOT and AND gates
+                let p0_a = p0_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 0 input A"))?;
+                let p0_b = p0_output_shares
+                    .get(&gate.inputs[1])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 0 input B"))?;
+                let p1_a = p1_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 1 input A"))?;
+                let p1_b = p1_output_shares
+                    .get(&gate.inputs[1])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 1 input B"))?;
+                let p2_a = p2_output_shares
+                    .get(&gate.inputs[0])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 2 input A"))?;
+                let p2_b = p2_output_shares
+                    .get(&gate.inputs[1])
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("Missing Party 2 input B"))?;
+
+                // NOT(A)
+                let not_a_shares = [
+                    not_gate_3party(0, p0_a),
+                    not_gate_3party(1, p1_a),
+                    not_gate_3party(2, p2_a),
+                ];
+
+                // NOT(B)
+                let not_b_shares = [
+                    not_gate_3party(0, p0_b),
+                    not_gate_3party(1, p1_b),
+                    not_gate_3party(2, p2_b),
+                ];
+
+                // NOT(A) AND NOT(B)
+                let and_shares = and_gate_3party_local([
+                    (not_a_shares[0], not_b_shares[0]),
+                    (not_a_shares[1], not_b_shares[1]),
+                    (not_a_shares[2], not_b_shares[2]),
+                ])?;
+
+                // NOT(NOT(A) AND NOT(B)) = A OR B
+                let p0_result = not_gate_3party(0, and_shares[0]);
+                let p1_result = not_gate_3party(1, and_shares[1]);
+                let p2_result = not_gate_3party(2, and_shares[2]);
+
+                p0_output_shares.insert(gate.id, p0_result);
+                p1_output_shares.insert(gate.id, p1_result);
+                p2_output_shares.insert(gate.id, p2_result);
+            }
+        }
+    }
+
+    Ok((p0_output_shares, p1_output_shares, p2_output_shares))
 }
 
-pub fn reconstruct_shares(share1: bool, share2: bool) -> bool {
-    share1 ^ share2
+/// Create secret shares for 2-party computation
+/// The secret value is split as: value = share0 ⊕ share1
+pub fn secret_share(value: bool) -> (bool, bool) {
+    let share0 = rand::random::<bool>();
+    let share1 = value ^ share0;
+    (share0, share1)
+}
+
+/// Reconstruct secret from 2 shares
+pub fn reconstruct_shares(share0: bool, share1: bool) -> bool {
+    share0 ^ share1
+}
+
+/// Create secret shares for 3-party computation
+/// The secret value is split as: value = share0 ⊕ share1 ⊕ share2
+pub fn secret_share_3party(value: bool) -> (bool, bool, bool) {
+    let share0 = rand::random::<bool>();
+    let share1 = rand::random::<bool>();
+    let share2 = value ^ share0 ^ share1;
+    (share0, share1, share2)
+}
+
+/// Reconstruct secret from 3 shares
+pub fn reconstruct_shares_3party(share0: bool, share1: bool, share2: bool) -> bool {
+    share0 ^ share1 ^ share2
 }


### PR DESCRIPTION
## Summary
- Implement 3-party GMW protocol with local simulation (Phase 1)
- Add unified execute_circuit interface supporting both 2-party and 3-party
- Fix clippy warnings with type alias for complex return types
- Create comprehensive 3-party gate implementations (AND, XOR, NOT, OR)

## Key Features
- **3-party secret sharing**: Values split into 3 XOR shares (x = x0 ⊕ x1 ⊕ x2)
- **Secure 3-party AND gates**: Uses cross-term computation with OT for xi·yj ⊕ xj·yi
- **Unified interface**: Single execute_circuit function handles both 2-party and 3-party
- **Consistent output format**: Both protocols return same result format
- **Local simulation**: Phase 1 implementation for testing and validation

## Implementation Details
- Added PartyShares enum to handle different party configurations
- Implemented cross-term computation for 3-party AND gates using existing OT
- Extended all basic gates (XOR, NOT, OR) for 3-party computation
- Maintained backward compatibility with existing 2-party circuits

## Test Plan
- [x] All existing 2-party tests pass
- [x] 3-party gates produce correct results
- [x] Circuit evaluation works for both 2-party and 3-party
- [x] Clippy warnings resolved
- [x] Unified interface integration with main.rs

🤖 Generated with [Claude Code](https://claude.ai/code)